### PR TITLE
fix: do not override return for GetBuildingColorDataForSlot

### DIFF
--- a/Source/KBFL/Private/KBFLModule.cpp
+++ b/Source/KBFL/Private/KBFLModule.cpp
@@ -28,15 +28,6 @@ void GetBuildingColorDataForSlot( CallScope< FFactoryCustomizationColorSlot( * )
 			}
 		}
 	}
-
-	if( !GameState ) {
-		UE_LOG( LogKBFLModule, Log, TEXT("Cancel function GetBuildingColorDataForSlot because GameState is currently INVALID!") );
-		scope.Override( FFactoryCustomizationColorSlot( ) );
-	}
-	else if( !GameState->GetWorld( ) ) {
-		UE_LOG( LogKBFLModule, Log, TEXT("Cancel function GetBuildingColorDataForSlot because GameState->GetWorld() is currently INVALID!") );
-		scope.Override( FFactoryCustomizationColorSlot( ) );
-	}
 }
 
 


### PR DESCRIPTION
Apparently, something about overriding this function's return value causes crashes on Linux dedicated servers. It's most likely because of the function's custom return type, as docs.ficsit.app contains a warning about this. Since overriding the function's return value is not necessary, simply remove the return overrides.